### PR TITLE
Reducer Modifier

### DIFF
--- a/Libraries/src/net/relinc/libraries/data/DataSubset.java
+++ b/Libraries/src/net/relinc/libraries/data/DataSubset.java
@@ -19,6 +19,35 @@ public abstract class DataSubset {
 	public abstract String getUnitAbbreviation(); // Each DataSubset has its standard units. e.g. Force=N
 	public abstract String getUnitName(); // e.g. Force = Newtons
 	
+	public void reduceDataNonReversible(int pointsToKeep) {
+		// This is non-reversible bowling-ball that modifies all the data... 
+		int reductionFactor = this.Data.timeData.length / pointsToKeep;
+		if(reductionFactor <= 1)
+		{
+			// TODO: log something somewhere...
+			return;
+		}
+		
+		double[] newTimeData = new double[pointsToKeep];
+		double[] newData = new double[pointsToKeep];
+		for(int i = 0; i < pointsToKeep; i++)
+		{
+			newTimeData[i] = this.Data.timeData[i * reductionFactor];
+			newData[i] = this.Data.data[i * reductionFactor];
+		}
+		
+		this.Data.timeData = newTimeData;
+		this.Data.data = newData;
+		
+		this.setBegin(this.getBegin() / reductionFactor);
+		this.setEnd(this.getEnd() / reductionFactor);
+		if(this.getBeginTemp() != null)
+			this.setBeginTemp(this.getBeginTemp() / reductionFactor);
+		if(this.getEndTemp() != null)
+			this.setEndTemp(this.getEnd() / reductionFactor);
+		
+	}
+	
 	public enum baseDataType{
 		LOAD, DISPLACEMENT, TIME;
 	}

--- a/Libraries/src/net/relinc/libraries/data/DataSubset.java
+++ b/Libraries/src/net/relinc/libraries/data/DataSubset.java
@@ -48,6 +48,12 @@ public abstract class DataSubset {
 		
 	}
 	
+	public void reduceDataNonReversibleByFrequency(double frequency) {
+		double reductionFactor = this.getFrequency() / frequency;
+		int pointsToKeep = this.Data.data.length / (int)reductionFactor;
+		reduceDataNonReversible(pointsToKeep);
+	}
+	
 	public enum baseDataType{
 		LOAD, DISPLACEMENT, TIME;
 	}
@@ -202,6 +208,10 @@ public abstract class DataSubset {
 	@Override
 	public String toString() {
 		return name;
+	}
+	
+	public double getFrequency() {
+		return 1.0 / (this.Data.timeData[1] - this.Data.timeData[0]);
 	}
 
 }

--- a/Libraries/src/net/relinc/libraries/sample/LoadDisplacementSampleResults.java
+++ b/Libraries/src/net/relinc/libraries/sample/LoadDisplacementSampleResults.java
@@ -70,7 +70,7 @@ public class LoadDisplacementSampleResults {
 			double interpolatedData;
 
 			if (idx < 0) {
-				interpolatedData = linearApprox(data, timeForData, timeNeeded, i, data.length - 6, 5);
+				interpolatedData = linearApprox(data, timeForData, timeNeeded, i, data.length - 6, 5); // 5 ???????
 			} else if (timeForData[idx] == timeNeeded[i]) {
 				interpolatedData = data[idx];
 			} else if (idx == 0) {
@@ -80,7 +80,6 @@ public class LoadDisplacementSampleResults {
 					interpolatedData = linearApprox(data, timeForData, timeNeeded, i, idx, 1);
 				} else {
 					interpolatedData = data[idx];
-					System.out.println("Rare Occurance " + idx);
 				}
 			}
 			newData[i] = interpolatedData;

--- a/Libraries/src/net/relinc/libraries/staticClasses/Dialogs.java
+++ b/Libraries/src/net/relinc/libraries/staticClasses/Dialogs.java
@@ -131,11 +131,13 @@ public final class Dialogs {
 		}
 	}
 	
-	public static double getDoubleValueFromUser(String prompt, String units){
+	private static TextField getValueFromUser(String prompt, Optional<String> units)
+	{
 		Stage anotherStage = new Stage();
 		Label label = new Label(prompt);
 		TextField tf = new TextField();
-		tf.setPromptText(units); //TODO: Moving Label
+		if(units.isPresent())
+			tf.setPromptText(units.get()); //TODO: Moving Label
 		Button button = new Button("Done");
 		button.setDefaultButton(true);
 		button.setOnAction(new EventHandler<ActionEvent>() {
@@ -161,38 +163,21 @@ public final class Dialogs {
 		
 		anotherStage.setScene(scene);
 		anotherStage.showAndWait();
+		return tf;
+	}
+	
+	public static double getDoubleValueFromUser(String prompt, String units){
+		TextField tf = getValueFromUser(prompt, Optional.of(units));
 		return Double.parseDouble(tf.getText().replaceAll(",", ""));
 	}
 	
+	public static int getIntValueFromUser(String prompt, String units) {
+		TextField tf = getValueFromUser(prompt, Optional.of(units));
+		return Integer.parseInt(tf.getText().replaceAll(",", ""));
+	}
+	
 	public static String getStringValueFromUser(String prompt){
-		Stage anotherStage = new Stage();
-		Label label = new Label(prompt);
-		TextField tf = new TextField();
-		Button button = new Button("Done");
-		button.setDefaultButton(true);
-		button.setOnAction(new EventHandler<ActionEvent>() {
-			@Override
-			public void handle(ActionEvent event) {
-				anotherStage.close();
-			}
-		});
-		VBox box = new VBox();
-		box.getChildren().add(label);
-		box.getChildren().add(tf);
-		box.getChildren().add(button);
-		box.setSpacing(15);
-		box.setAlignment(Pos.CENTER);
-		box.setPadding(new Insets(10.0));
-		AnchorPane anchor = new AnchorPane();
-		AnchorPane.setBottomAnchor(box, 0.0);
-		AnchorPane.setTopAnchor(box, 0.0);
-		AnchorPane.setLeftAnchor(box, 0.0);
-		AnchorPane.setRightAnchor(box, 0.0);
-		anchor.getChildren().add(box);
-		Scene scene = new Scene(anchor, 400, 220);
-		
-		anotherStage.setScene(scene);
-		anotherStage.showAndWait();
+		TextField tf = getValueFromUser(prompt, Optional.empty());
 		return tf.getText();
 	}
 	

--- a/Viewer/src/net/relinc/viewer/GUI/DataReducerDialog.java
+++ b/Viewer/src/net/relinc/viewer/GUI/DataReducerDialog.java
@@ -13,19 +13,19 @@ import javafx.scene.Scene;
 import javafx.scene.control.Button;
 import javafx.scene.control.Label;
 import javafx.scene.control.RadioButton;
-import javafx.scene.control.TextField;
 import javafx.scene.control.ToggleGroup;
 import javafx.scene.layout.AnchorPane;
+import javafx.scene.layout.GridPane;
 import javafx.scene.layout.HBox;
 import javafx.scene.layout.VBox;
 import javafx.stage.Stage;
+import net.relinc.libraries.fxControls.NumberTextField;
 
 public class DataReducerDialog {
 	static Map<String, Number> showDataReducerDialog() {
 		Stage stage = new Stage();
 		Label label = new Label("Reduce Data");
-		TextField tf = new TextField();
-		tf.setPromptText("Points To Keep");
+		NumberTextField tf = new NumberTextField("points", "hertz");
 		Button button = new Button("Done");
 		button.setDefaultButton(true);
 		button.setOnAction(new EventHandler<ActionEvent>() {
@@ -42,9 +42,9 @@ public class DataReducerDialog {
 			@Override
 			public void changed(ObservableValue<? extends Boolean> observable, Boolean oldValue, Boolean newValue) {
 				if(newValue) {
-					tf.setPromptText("Points To Keep");
+					tf.unitLabel.setText("points");
 				} else {
-					tf.setPromptText("Data Collection Frequency");
+					tf.unitLabel.setText("hertz");
 				}
 			}
 		});
@@ -60,7 +60,11 @@ public class DataReducerDialog {
 		hBox.setAlignment(Pos.CENTER);
 		hBox.setSpacing(5);
 		box.getChildren().add(hBox);
-		box.getChildren().add(tf);
+		GridPane view = new GridPane();
+		view.add(tf, 0, 0);
+		view.add(tf.unitLabel, 0, 0);
+		view.setAlignment(Pos.CENTER);
+		box.getChildren().add(view);
 		box.getChildren().add(button);
 		box.setSpacing(15);
 		box.setAlignment(Pos.CENTER);

--- a/Viewer/src/net/relinc/viewer/GUI/DataReducerDialog.java
+++ b/Viewer/src/net/relinc/viewer/GUI/DataReducerDialog.java
@@ -1,0 +1,86 @@
+package net.relinc.viewer.GUI;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import javafx.beans.value.ChangeListener;
+import javafx.beans.value.ObservableValue;
+import javafx.event.ActionEvent;
+import javafx.event.EventHandler;
+import javafx.geometry.Insets;
+import javafx.geometry.Pos;
+import javafx.scene.Scene;
+import javafx.scene.control.Button;
+import javafx.scene.control.Label;
+import javafx.scene.control.RadioButton;
+import javafx.scene.control.TextField;
+import javafx.scene.control.ToggleGroup;
+import javafx.scene.layout.AnchorPane;
+import javafx.scene.layout.HBox;
+import javafx.scene.layout.VBox;
+import javafx.stage.Stage;
+
+public class DataReducerDialog {
+	static Map<String, Number> showDataReducerDialog() {
+		Stage stage = new Stage();
+		Label label = new Label("Reduce Data");
+		TextField tf = new TextField();
+		tf.setPromptText("Points To Keep");
+		Button button = new Button("Done");
+		button.setDefaultButton(true);
+		button.setOnAction(new EventHandler<ActionEvent>() {
+			@Override
+			public void handle(ActionEvent event) {
+				stage.close();
+			}
+		});
+		VBox box = new VBox();
+		
+		box.getChildren().add(label);
+		RadioButton pointsToKeepMode = new RadioButton("Points To Keep");
+		pointsToKeepMode.selectedProperty().addListener(new ChangeListener<Boolean>() {
+			@Override
+			public void changed(ObservableValue<? extends Boolean> observable, Boolean oldValue, Boolean newValue) {
+				if(newValue) {
+					tf.setPromptText("Points To Keep");
+				} else {
+					tf.setPromptText("Data Collection Frequency");
+				}
+			}
+		});
+		pointsToKeepMode.setSelected(true);
+		RadioButton frequencyMode = new RadioButton("Frequency");
+		ToggleGroup group = new ToggleGroup();
+		pointsToKeepMode.setToggleGroup(group);
+		frequencyMode.setToggleGroup(group);
+		
+		HBox hBox = new HBox();
+		hBox.getChildren().add(pointsToKeepMode);
+		hBox.getChildren().add(frequencyMode);
+		hBox.setAlignment(Pos.CENTER);
+		hBox.setSpacing(5);
+		box.getChildren().add(hBox);
+		box.getChildren().add(tf);
+		box.getChildren().add(button);
+		box.setSpacing(15);
+		box.setAlignment(Pos.CENTER);
+		box.setPadding(new Insets(10.0));
+		AnchorPane anchor = new AnchorPane();
+		AnchorPane.setBottomAnchor(box, 0.0);
+		AnchorPane.setTopAnchor(box, 0.0);
+		AnchorPane.setLeftAnchor(box, 0.0);
+		AnchorPane.setRightAnchor(box, 0.0);
+		anchor.getChildren().add(box);
+		Scene scene = new Scene(anchor, 400, 220);
+		
+		stage.setScene(scene);
+		stage.showAndWait();
+		Map<String, Number> ret = new HashMap<String, Number>();
+		if(pointsToKeepMode.isSelected()) {
+			ret.put("pointsToKeep", Integer.parseInt(tf.getText().replaceAll(",", "")));
+		} else {
+			ret.put("frequency", Double.parseDouble(tf.getText().replaceAll(",", "")));
+		}
+		return ret;
+	}
+}

--- a/Viewer/src/net/relinc/viewer/GUI/Home.fxml
+++ b/Viewer/src/net/relinc/viewer/GUI/Home.fxml
@@ -43,6 +43,7 @@
                                     <VBox fx:id="leftVBox" alignment="TOP_CENTER" layoutX="-75.0" layoutY="-262.0" prefHeight="180.0" prefWidth="200.0" spacing="10.0" AnchorPane.bottomAnchor="0.0" AnchorPane.leftAnchor="0.0" AnchorPane.rightAnchor="0.0" AnchorPane.topAnchor="0.0">
                                        <children>
                                           <Label text="Currently Loaded Samples" />
+                                          <Button mnemonicParsing="false" onAction="#reduceDataSizeButtonFired" text="Reduce Data Size" />
                                           <HBox alignment="CENTER" spacing="10.0">
                                              <children>
                                                 <Button mnemonicParsing="false" onAction="#checkAllButtonFired" text="Check All" />

--- a/Viewer/src/net/relinc/viewer/GUI/HomeController.java
+++ b/Viewer/src/net/relinc/viewer/GUI/HomeController.java
@@ -5,6 +5,8 @@ import java.text.DecimalFormat;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Map;
+
 import javax.imageio.ImageIO;
 import org.controlsfx.control.CheckListView;
 import org.controlsfx.control.PopOver;
@@ -724,11 +726,17 @@ public class HomeController extends CommonGUI {
 
 	@FXML
 	public void reduceDataSizeButtonFired() {
-		int pointsToKeep = Dialogs.getIntValueFromUser("Points To Keep", "# of points");
+		Map<String, Number> reduceParams = DataReducerDialog.showDataReducerDialog();
 		getCheckedSamples().stream().forEach(sample -> {
             sample.DataFiles.stream().forEach(df -> {
                 df.dataSubsets.stream().forEach(subset -> {
-                        subset.reduceDataNonReversible(pointsToKeep);
+                		if(reduceParams.containsKey("pointsToKeep"))
+                		{
+                			subset.reduceDataNonReversible(reduceParams.get("pointsToKeep").intValue());
+                		} else {
+                			subset.reduceDataNonReversibleByFrequency(reduceParams.get("frequency").doubleValue());
+                		}
+                        
                 });
             });
 		});

--- a/Viewer/src/net/relinc/viewer/GUI/HomeController.java
+++ b/Viewer/src/net/relinc/viewer/GUI/HomeController.java
@@ -729,17 +729,16 @@ public class HomeController extends CommonGUI {
 	public void reduceDataSizeButtonFired() {
 		Map<String, Number> reduceParams = DataReducerDialog.showDataReducerDialog();
 		getCheckedSamples().stream().forEach(sample -> {
-            sample.DataFiles.stream().forEach(df -> {
-                df.dataSubsets.stream().forEach(subset -> {
-                		if(reduceParams.containsKey("pointsToKeep"))
-                		{
-                			subset.reduceDataNonReversible(reduceParams.get("pointsToKeep").intValue());
-                		} else {
-                			subset.reduceDataNonReversibleByFrequency(reduceParams.get("frequency").doubleValue());
-                		}
-                        
-                });
-            });
+			sample.DataFiles.stream().forEach(df -> {
+				df.dataSubsets.stream().forEach(subset -> {
+					if (reduceParams.containsKey("pointsToKeep")) {
+						subset.reduceDataNonReversible(reduceParams.get("pointsToKeep").intValue());
+					} else {
+						subset.reduceDataNonReversibleByFrequency(reduceParams.get("frequency").doubleValue());
+					}
+
+				});
+			});
 		});
 		renderSampleResults();
 		renderCharts();

--- a/Viewer/src/net/relinc/viewer/GUI/HomeController.java
+++ b/Viewer/src/net/relinc/viewer/GUI/HomeController.java
@@ -722,6 +722,21 @@ public class HomeController extends CommonGUI {
 
 	}
 
+	@FXML
+	public void reduceDataSizeButtonFired() {
+		int pointsToKeep = Dialogs.getIntValueFromUser("Points To Keep", "# of points");
+		getCheckedSamples().stream().forEach(sample -> {
+            sample.DataFiles.stream().forEach(df -> {
+                df.dataSubsets.stream().forEach(subset -> {
+                        subset.reduceDataNonReversible(pointsToKeep);
+                });
+            });
+		});
+		renderSampleResults();
+		renderCharts();
+	}
+	
+	@FXML
 	public void checkAllButtonFired(){
 		realCurrentSamplesListView.getItems().stream().forEach(sample -> sample.selectedProperty().removeListener(sampleCheckedListener));
 		realCurrentSamplesListView.getItems().forEach(s -> s.setSelected(true));
@@ -729,6 +744,7 @@ public class HomeController extends CommonGUI {
 		sampleCheckedListener.changed(null, true, false);
 	}
 
+	@FXML
 	public void uncheckAllButtonFired(){
 		realCurrentSamplesListView.getItems().stream().forEach(sample -> sample.selectedProperty().removeListener(sampleCheckedListener));
 		realCurrentSamplesListView.getItems().forEach(s -> s.setSelected(false)); //


### PR DESCRIPTION
This is the safest/easiest modifier I could come up with. There is a new button in the viewer:

![image](https://user-images.githubusercontent.com/7853605/44302444-a6ddac00-a2f6-11e8-8d47-5bb336ef8a85.png)


__Downsides__:
- It is a non-reversible filter. If you mess up, you have to remove the sample and add it again.
- This is not savable 
- Saving a Sample Session will save the wrong `beginTemp` and `endTemp`
   - I'm pretty sure this is currently wrong
- Do filter frequencies still make sense? I think it is still correct, it should adjust since the timestep changed.


We could also show the user more information about what their "Points To Keep" selection will do.. aka "This will result in a 10X speedup in calculations".
