### PR TITLE
fix linux/graphing issues

### DIFF
--- a/Libraries/src/net/relinc/libraries/data/DataSubset.java
+++ b/Libraries/src/net/relinc/libraries/data/DataSubset.java
@@ -128,11 +128,11 @@ public abstract class DataSubset {
 		// due to modifiers changing the density of data, specifically the Sampler modifier, we need to let them scale the userIndex
 		// userIndex is the index of the data in relation to the modified data.
 		// original indexes are always kept in this class
-		return (int)(userIndex * (1.0 / getModifierResult().getUserIndexToOriginalIndexRatio()));
+		return Math.min((int)Math.round(userIndex * (1.0 / getModifierResult().getUserIndexToOriginalIndexRatio())), Data.getOriginalDataPoints());
 	}
 
 	private int originalIndexToUserIndex(int originalIndex) {
-		return (int)(originalIndex * getModifierResult().getUserIndexToOriginalIndexRatio());
+		return (int)Math.round(originalIndex * getModifierResult().getUserIndexToOriginalIndexRatio());
 	}
 	
 	public void setEndTemp(Integer e){

--- a/build.gradle
+++ b/build.gradle
@@ -49,7 +49,7 @@ sourceSets {
 }
 
 ext.update_version_info = {version_info->
-    File file = new File('DataProcessor/lib/surepulseversioninfo.txt')
+    File file = new File("$projectDir/DataProcessor/lib/surepulseversioninfo.txt")
     file.write("version:"+version_info)
 }
 dependencies {


### PR DESCRIPTION
DataSubset
Math.round fixes trim such that w/ small sample points, trim increment >=0.
Math.min prevents out of index bounds exception

build.gradle
directory change allows it to run in Linux
recommend test in windows/mac